### PR TITLE
Added Coder Consortium as a User Group in North America

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -335,6 +335,10 @@ usergroups {
         location 'North-America/United States'
         url 'http://www.scottsdale-groovy.com/'
     }
+    userGroup('Coder Consortium of Sacramento') {
+        location 'North-America/United States'
+        url 'http://coderconsortium.com/'
+    }
 
     // South-America
     userGroup('Grails Brasil - Groovy and Grails users group of Brazil') {


### PR DESCRIPTION
Although Coder Consortium isn't an ONLY groovy/grails user group it's origins started with SacGRU (Sacramento Groovy Users) in 2008.  We still discuss groovy and groovy projects in most meetings so I still consider us part of the community.
