### PR TITLE
fixed groovyconsole and groovysh links

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -95,7 +95,7 @@ documentation {
     section ('Tools','fa-gears') {
         item 'groovyc — the Groovy compiler',               'groovyc',          'tools-groovyc'
         item 'groovysh — the Groovy command -like shell',   'groovysh',         'groovysh'
-        item 'groovyConsole — the Groovy Swing console',    'groovyconsole',    'groovyconsole'
+        item 'groovyConsole — the Groovy Swing console',    'groovyconsole',    'groovy-console'
         item 'IDE integration', 'ides', 'tools-ide'
     }
 

--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -94,8 +94,8 @@ documentation {
 
     section ('Tools','fa-gears') {
         item 'groovyc — the Groovy compiler',               'groovyc',          'tools-groovyc'
-        item 'groovysh — the Groovy command -like shell',   'groovysh',         'tools-groovysh'
-        item 'groovyConsole — the Groovy Swing console',    'groovyconsole',    'tools-groovyconsole'
+        item 'groovysh — the Groovy command -like shell',   'groovysh',         'groovysh'
+        item 'groovyConsole — the Groovy Swing console',    'groovyconsole',    'groovyconsole'
         item 'IDE integration', 'ides', 'tools-ide'
     }
 


### PR DESCRIPTION
Unless I'm misunderstanding I believe the links in the [sitemap](https://github.com/groovy/groovy-website/blob/master/site/src/site/sitemap.groovy) don't match the filenames of [groovy-console](https://github.com/groovy/groovy-core/blob/master/subprojects/groovy-console/src/spec/doc/groovy-console.adoc) and [groovsh](https://github.com/groovy/groovy-core/blob/master/subprojects/groovy-groovysh/src/spec/doc/groovysh.adoc).

Let me know if I'm not understanding how the groovy-website is stitched together with the Asciidocs from groovy-core.