### PR TITLE
Apache logo in footer break site layout

### DIFF
--- a/site/src/site/assets/css/style.css
+++ b/site/src/site/assets/css/style.css
@@ -423,6 +423,10 @@ h8 {
     padding-top: 10px
 }
 
+#footer .col-right img {
+  width: 100%;
+}
+
 #footer .colset-3-footer {
     color: #222;
     font-size: 14px


### PR DESCRIPTION
The Apache logo in the footer broke the site layout since it was too
wide.