### PR TITLE
Cleanup to Community UGs

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -355,10 +355,6 @@ usergroups {
         location 'North-America/United States'
         url 'http://coderconsortium.com/'
     }
-    userGroup('DC Groovy') {
-        location 'North-America/United States'
-        url 'http://www.dcgroovy.org'
-    }
     userGroup('DFW Groovy & Grails User Group') {
         location 'North-America/United States'
         url 'http://dfw2gug.org'


### PR DESCRIPTION
I went through all User Groups and only found one that was inactive and had no history. Removed the DC Groovy link which pointed to a defunct Meetup group. All other groups are valid sites.