### PR TITLE
Add Slack community link

### DIFF
--- a/site/src/site/pages/community.groovy
+++ b/site/src/site/pages/community.groovy
@@ -27,7 +27,7 @@ layout 'layouts/main.groovy', true,
                                 ul {
                                     li "how you can ${$a(href: 'contribute.html', 'contribute')} to the project, its codebase, its documentation,"
                                     li "how to raise issues in our ${$a(href: 'contribute.html#reporting-issues', 'bug tracker')},"
-                                    li "how to interact with other Groovy users and developers through the ${$a(href: 'mailing-lists.html', 'mailing-lists')},"
+                                    li "how to interact with other Groovy users and developers through the ${$a(href: 'mailing-lists.html', 'mailing-lists')} or ${$a(href: 'https://groovycommunity.com/', 'Slack')},"
                                     li "the upcoming ${$a(href: 'events.html', 'events and conferences')} you might want to attend to learn more about Groovy and to share your experience with others,"
                                     li "the list of ${$a(href: 'usergroups.html', 'user groups')} you can attend and where to meet other Groovy users."
                                 }

--- a/site/src/site/pages/community.groovy
+++ b/site/src/site/pages/community.groovy
@@ -27,7 +27,7 @@ layout 'layouts/main.groovy', true,
                                 ul {
                                     li "how you can ${$a(href: 'contribute.html', 'contribute')} to the project, its codebase, its documentation,"
                                     li "how to raise issues in our ${$a(href: 'contribute.html#reporting-issues', 'bug tracker')},"
-                                    li "how to interact with other Groovy users and developers through the ${$a(href: 'mailing-lists.html', 'mailing-lists')} or ${$a(href: 'https://groovycommunity.com/', 'Slack')},"
+                                    li "how to interact with other Groovy users and developers through the ${$a(href: 'mailing-lists.html', 'mailing-lists')} or ${$a(href: 'https://groovycommunity.com/', 'Slack')}. The Slack channel is not endorsed by the Apache Software Foundation, It's run by Groovy enthusiasts in the community for casual conversations and Q&A. Official discussions must happen on the mailing lists only,"
                                     li "the upcoming ${$a(href: 'events.html', 'events and conferences')} you might want to attend to learn more about Groovy and to share your experience with others,"
                                     li "the list of ${$a(href: 'usergroups.html', 'user groups')} you can attend and where to meet other Groovy users."
                                 }


### PR DESCRIPTION
Adds a link to the new Groovy Slack community: https://groovycommunity.com/

For more info, please refer to @danveloper blog post: http://danveloper.github.io/announcing-groovy-community-slack.html