### PR TITLE
Adding Boston Groovy/Grails meetup to userGroups

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -354,6 +354,10 @@ usergroups {
         location 'North-America/United States'
         url 'http://www.meetup.com/Austin-Groovy-and-Grails-Users/'
     }
+    userGroup('Boston Groovy, Grails, Spring Meetup (B2GS)') {
+        location 'North-America/United States'
+        url 'https://www.meetup.com/Grails-Boston/'
+    }
     userGroup('Coder Consortium of Sacramento') {
         location 'North-America/United States'
         url 'http://coderconsortium.com/'


### PR DESCRIPTION
Just adding the Boston Groovy, Grails, Spring Meetup (B2GS) to the userGroup section.